### PR TITLE
Update Compass.sublime-build

### DIFF
--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,10 +1,10 @@
 {
-	"cmd": ["cd $project_path;", "compass watch"],
-    "working_dir": "$packages/Compass",
-    "selector": "source.sass",
-    "shell":		"true",
+	"cmd": "cd '$project_path'; compass watch",
+	"working_dir": "$packages/Compass",
+	"selector": "source.sass",
+	"shell": "true",
 	"windows":
-	    {
-	        "cmd": ["compasswatch.bat", "$project_path"]
-	    }
+	{
+		"cmd": ["compasswatch.bat", "$project_path"]
+	}
 }


### PR DESCRIPTION
Refactored tabs/spaces, changed comand syntax (for linux support), fixed error with CD to directory that contains spaces in path.
