### PR TITLE
Fix for Issue 16

### DIFF
--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,5 +1,5 @@
 {
-	"cmd": "cd '${file_path}'; compass watch",
+	"cmd": "cd '${file_path}'; compass watch --boring",
 	"working_dir": "$packages/Compass",
 	"selector": "source.sass, source.scss",
 	"shell": "true",


### PR DESCRIPTION
## [Issue #16](https://github.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/issues/16)

Replacing `$project_path` with `${file_path}` in build file. (Thanks to @drwlrsn for the correction)
