### PR TITLE
A (possible) better fix for Issue 16

### DIFF
--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,10 +1,10 @@
 {
-	"cmd": "cd '${file_path}'; compass watch --boring",
+	"cmd": "[ -r '${project_path:${folder}}/config.rb' ] && compass watch '${project_path:${folder}}' --boring; [ -r '${file_path}/config.rb' ] && compass watch '${file_path}' --boring",
 	"working_dir": "$packages/Compass",
 	"selector": "source.sass, source.scss",
 	"shell": "true",
 	"windows":
 	{
-		"cmd": ["compasswatch.bat", "${file_path}"]
+		"cmd": ["compasswatch.bat", "${project_path:${folder}}", "${file_path}"]
 	}
 }

--- a/compasswatch.bat
+++ b/compasswatch.bat
@@ -1,2 +1,8 @@
-compass watch %1  --boring
+IF EXIST %1\config.rb (
+	REM compass watch %1 --boring
+)
+
+IF EXIST %2\config.rb (
+	REM compass watch %2 --boring
+)
 pause


### PR DESCRIPTION
Because there are at least two use cases for Compass we should check where the config.rb file is. First we check whether config.rb is in the sublime project's root. If it is not there, then we check to see if the config.rb file is in the same directory as the .sass or .scss file.

I don't have a Windows computer to test `compasswatch.bat` so I have no idea if that works.
