### PR TITLE
Delegate build to script. Find config.rb up the directory tree

### DIFF
--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,10 +1,10 @@
 {
-	"cmd": "[ -r '${project_path:${folder}}/config.rb' ] && compass watch '${project_path:${folder}}' --boring; [ -r '${file_path}/config.rb' ] && compass watch '${file_path}' --boring",
+	"cmd": "sh '${packages}/Compass/build.sh' ${file_path} ${project_path:${folder}}",
 	"working_dir": "$packages/Compass",
 	"selector": "source.sass, source.scss",
 	"shell": "true",
 	"windows":
 	{
-		"cmd": ["compasswatch.bat", "${project_path:${folder}}", "${file_path}"]
+		"cmd": ["build.cmd", "${file_path}", "${project_path:${folder}}"]
 	}
 }

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,17 @@
+@echo off
+setlocal EnableDelayedExpansion
+set fileDir=%~dp1
+
+:loop
+for %%F in ("%fileDir%\..") do if not exist "%%~fF\config.rb" (
+  if %fileDir% neq %%~fF (
+    set "fileDir=%%~fF"
+    goto :loop
+  ) else set "fileDir="
+) else set "fileDir=%%~fF"
+
+if not defined fileDir (
+  echo [ERROR] config.rb not found.
+) else (
+  compass compile %fileDir% --boring
+)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+FILE_PATH=$1;
+PROJECT_PATH=${2-/};
+COMPASS=`which compass`;
+
+if [[ -z "$COMPASS" ]]; then
+  echo "[ERROR] compass not found. Make sure it exists in your PATH.";
+  exit;
+fi
+
+while [ "$FILE_PATH" != "$PROJECT_PATH" ];
+  do FILE_PATH=`dirname "$FILE_PATH"`;
+
+  if [ `find "$FILE_PATH" -maxdepth 1 -name config.rb` ]; then
+    $COMPASS compile "$FILE_PATH" --boring;
+    FOUND=1;
+    break;
+  fi;
+done
+
+if [[ -z "$FOUND" ]]; then
+  echo "[ERROR] Build did not run because config.rb cannot be found.";
+fi

--- a/compasswatch.bat
+++ b/compasswatch.bat
@@ -1,8 +1,0 @@
-IF EXIST %1\config.rb (
-	compass watch %1 --boring
-)
-
-IF EXIST %2\config.rb (
-	compass watch %2 --boring
-)
-pause


### PR DESCRIPTION
This patch delegates the build process to shell scripts for easier maintenance.

The script parses the directory tree upwards and looks for config.rb and then executes the build in the correct folder - e.g where config.rb is. This enables the use of the build system in complex projects where the config.rb is not necessarily in the project root and the sass file can be several directory levels down from the compass config file.

Also changed the build command from `compass watch` to `compass compile` as the watch command does not exit and subsequent build runs generate several zombie ruby processes eating up resources.

Tested and working on OS X 10.7 and on Windows 7 so far.
