### PR TITLE
Add "path" key to Compass.sublime-build

### DIFF
--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,11 +1,14 @@
 {
 	"cmd": "sh '${packages}/Compass/build.sh' '${file_path}' '${project_path:${folder}}'",
-	"path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
 	"working_dir": "$packages/Compass",
 	"selector": "source.sass, source.scss",
 	"shell": "true",
 	"windows":
 	{
 		"cmd": "build.cmd \"${file_path}\" \"${project_path:${folder}}\""
+	},
+	"osx": 
+	{
+		"path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 	}
 }

--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -1,5 +1,6 @@
 {
 	"cmd": "sh '${packages}/Compass/build.sh' '${file_path}' '${project_path:${folder}}'",
+	"path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
 	"working_dir": "$packages/Compass",
 	"selector": "source.sass, source.scss",
 	"shell": "true",

--- a/Compass.sublime-build
+++ b/Compass.sublime-build
@@ -9,6 +9,6 @@
 	},
 	"osx": 
 	{
-		"path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
+		"path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 	}
 }


### PR DESCRIPTION
Added path key to account for applications running at a different path in El Capitan.

Before I added in the path key, I would get `[ERROR] compass not found. Make sure it exists in your PATH.` This is because the path was only /usr/bin, but compass existed at /user/local/bin.

I'm not sure if an override is necessary for windows, and if it is, I don't know what it should be.
